### PR TITLE
Add support to google cloud storage

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -62,6 +62,8 @@ uwsgi = {version = ">=2.0.0", platform_system = "!= 'Windows'"}
 celery = {version = "*", extras = ["redis"]}
 weasyprint = ">=0.42.2"
 graphene-django-optimizer = "*"
+google-cloud = "==0.34.* "
+google-cloud-storage = "==1.10.*"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "33e0eaa63ebe20fded56f29df26d33f0c517fc604c625d4c979b8ebb3bc7d494"
+            "sha256": "9e24b26145b1bf63e6681753c75a40e13056f5d4041d673928d76cc5e08215cb"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -39,9 +39,9 @@
         },
         "autopep8": {
             "hashes": [
-                "sha256:655e3ee8b4545be6cfed18985f581ee9ecc74a232550ee46e9797b6fbf4f336d"
+                "sha256:1b8d42ebba751a91090d3adb5c06840b1151d71ed43e1c7a9ed6911bfe8ebe6c"
             ],
-            "version": "==1.4"
+            "version": "==1.4.2"
         },
         "babel": {
             "hashes": [
@@ -67,25 +67,32 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:b9664b5e11dc5d3e2b546609f2c86e457ac1b4b596fee18322fa3667ce730f88",
-                "sha256:b9e5a9c4c70d06a7aca9270ea4b4f69577c9107a891ab6de279565284c335eb1"
+                "sha256:03bdbd5bfc8c9f603877edf208a947b9e9d3d29268e3c3c46c3a8ee3d64ccda8",
+                "sha256:bc7b8e65b9612ee7ff03f71e765d0f380c8db096d898213bb4ead5b389c31cde"
             ],
             "index": "pypi",
-            "version": "==1.9.19"
+            "version": "==1.9.31"
         },
         "botocore": {
             "hashes": [
-                "sha256:0f0a2a74a9dc1d53531f559477f329ad087f3b378fc9cf02e67017e475854f8d",
-                "sha256:bc2fa51e05afb944f4f684c7d52a0db165898985d46b2fcb55fb842028fcc7a6"
+                "sha256:409edb0651313a04e93f2bfff2663ef84f742034f2099478d07b0c508b921c02",
+                "sha256:dea459bfa0418689f2dfd8241739e7bb071d1cc944ffcc9cce0c19ecaf3612f3"
             ],
-            "version": "==1.12.19"
+            "version": "==1.12.31"
         },
         "braintree": {
             "hashes": [
-                "sha256:63718892d03ebc5574b91ac7534c6038e8ca3c290db64d6df865c0b17f8b94b1",
-                "sha256:b1d65933f22fff8e130d6808bc7ce2b4db47416faf92bb87265531dad2637ccd"
+                "sha256:0c95dbe0b497fd2eafaa08b6282f2b1d547cba3a432f8101424bd06c333348b5",
+                "sha256:7cdd715a5a61339e4e5dcb5611cf80512d5fdb0e4da69307a64141d3597357f7"
             ],
-            "version": "==3.48.0"
+            "version": "==3.49.0"
+        },
+        "cachetools": {
+            "hashes": [
+                "sha256:90f1d559512fc073483fe573ef5ceb39bf6ad3d39edc98dc55178a2b2b176fa3",
+                "sha256:d1c398969c478d336f767ba02040fa22617333293fb0b8968e79b16028dfee35"
+            ],
+            "version": "==2.1.0"
         },
         "cairocffi": {
             "hashes": [
@@ -102,6 +109,9 @@
             "version": "==2.2.1"
         },
         "celery": {
+            "extras": [
+                "redis"
+            ],
             "hashes": [
                 "sha256:77dab4677e24dc654d42dfbdfed65fa760455b6bb563a0877ecc35f4cfcfc678",
                 "sha256:ad7a7411772b80a4d6c64f2f7f723200e39fb66cf614a7fdfab76d345acc7b13"
@@ -111,10 +121,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:376690d6f16d32f9d1fe8932551d80b23e9d393a8578c5633a2ed39a64861638",
-                "sha256:456048c7e371c089d0a77a5212fb37a2c2dce1e24146e3b7e0261736aaeaa22a"
+                "sha256:339dc09518b07e2fa7eda5450740925974815557727d6bd35d319c1524a04a4c",
+                "sha256:6d58c986d22b038c8c0df30d639f23a3e6d172a05c3583e766f4c0b785c0986a"
             ],
-            "version": "==2018.8.24"
+            "version": "==2018.10.15"
         },
         "cffi": {
             "hashes": [
@@ -309,11 +319,11 @@
         },
         "django-graphql-jwt": {
             "hashes": [
-                "sha256:619e76d3eabd05732f3e267ddb6d60e5e63a119002f91b316de26cdf66699d25",
-                "sha256:f00a135baef6729b5816b32ea97f0fd49925d16e07054013139938295f1d5e66"
+                "sha256:56168bc2f85283fbe6569357051c7d5ea4acb0ef0d56436e3f01dde9bf7c9b4e",
+                "sha256:690683a9f619b8c785f0297aa7e6ea7a047877b59b3417d550591899a119e58e"
             ],
             "index": "pypi",
-            "version": "==0.1.13"
+            "version": "==0.1.14"
         },
         "django-impersonate": {
             "hashes": [
@@ -465,19 +475,56 @@
         },
         "faker": {
             "hashes": [
-                "sha256:74b32991f8e08e4f2f84858b919eca253becfaec4b3fa5fcff7fdbd70d5d78b1",
-                "sha256:c2ce42dd8361e6d392276006d757532562463c8642b1086709584200b7fd7758"
+                "sha256:2621643b80a10b91999925cfd20f64d2b36f20bf22136bbdc749bb57d6ffe124",
+                "sha256:5ed822d31bd2d6edf10944d176d30dc9c886afdd381eefb7ba8b7aad86171646"
             ],
             "index": "pypi",
-            "version": "==0.9.1"
+            "version": "==0.9.2"
         },
         "freezegun": {
             "hashes": [
-                "sha256:703caac155dcaad61f78de4cb0666dca778d854dfb90b3699930adee0559a622",
-                "sha256:94c59d69bb99c9ec3ca5a3adb41930d3ea09d2a9756c23a02d89fa75646e78dd"
+                "sha256:6cb82b276f83f2acce67f121dc2656f4df26c71e32238334eb071170b892a278",
+                "sha256:e839b43bfbe8158b4d62bb97e6313d39f3586daf48e1314fb1083d2ef17700da"
             ],
             "index": "pypi",
-            "version": "==0.3.10"
+            "version": "==0.3.11"
+        },
+        "google-api-core": {
+            "hashes": [
+                "sha256:034215fd86972dd329b979a6acb89fb60fa0aaaf0ea4730401effde3b7aab19b",
+                "sha256:13851b321a214ffa19c9caea6d6bf355a9021bed455c2afb03546704db5de247"
+            ],
+            "version": "==1.5.0"
+        },
+        "google-auth": {
+            "hashes": [
+                "sha256:9ca363facbf2622d9ba828017536ccca2e0f58bd15e659b52f312172f8815530",
+                "sha256:a4cf9e803f2176b5de442763bd339b313d3f1ed3002e3e1eb6eec1d7c9bbc9b4"
+            ],
+            "version": "==1.5.1"
+        },
+        "google-cloud": {
+            "hashes": [
+                "sha256:01430187cf56df10a9ba775dd547393185d4b40741db0ea5889301f8e7a9d5d3",
+                "sha256:fb1ab7b0548fe44b3d538041f0a374505b7f990d448a935ea36649c5ccab5acf"
+            ],
+            "index": "pypi",
+            "version": "==0.34.0"
+        },
+        "google-cloud-core": {
+            "hashes": [
+                "sha256:0090df83dbc5cb2405fa90844366d13176d1c0b48181c1807ab15f53be403f73",
+                "sha256:89e8140a288acec20c5e56159461d3afa4073570c9758c05d4e6cb7f2f8cc440"
+            ],
+            "version": "==0.28.1"
+        },
+        "google-cloud-storage": {
+            "hashes": [
+                "sha256:6e53ee063e5075dc69322162fdf7e1b2a51eac82ec0449293e471fa8f36cdeba",
+                "sha256:c1969558df8d7994cf4f89f60c01c619d77fc19facb38f66640d1f749a663e2e"
+            ],
+            "index": "pypi",
+            "version": "==1.10.0"
         },
         "google-i18n-address": {
             "hashes": [
@@ -493,6 +540,19 @@
             ],
             "index": "pypi",
             "version": "==1.0.0"
+        },
+        "google-resumable-media": {
+            "hashes": [
+                "sha256:116de90b9cd483b17c53618ee6a5a20f33e741c648140c8cc9c2141e07616ff1",
+                "sha256:97de518f8166d442cc0b61fab308bcd319dbb970981e667ec8ded44f5ce49836"
+            ],
+            "version": "==0.3.1"
+        },
+        "googleapis-common-protos": {
+            "hashes": [
+                "sha256:c075eddaa2628ab519e01b7d75b76e66c40eaa50fc52758d8225f84708950ef2"
+            ],
+            "version": "==1.5.3"
         },
         "gprof2dot": {
             "hashes": [
@@ -514,6 +574,14 @@
             ],
             "index": "pypi",
             "version": "==2.2.0"
+        },
+        "graphene-django-optimizer": {
+            "hashes": [
+                "sha256:332f48d318e18dc58f89deaf79d51a0d25e5499d04d839a255bfac24dcac42e5",
+                "sha256:f104e3cfba65f3aef591bf3a9859915abfa074eccb4508e5af19a90a3091f9ee"
+            ],
+            "index": "pypi",
+            "version": "==0.3.5"
         },
         "graphql-core": {
             "hashes": [
@@ -626,18 +694,18 @@
         },
         "phonenumbers": {
             "hashes": [
-                "sha256:670ccaa36eb2c4c05902e461f78e480403257507351b3c98660f2c7f15eb9474",
-                "sha256:8e9664ce0a838c81f4fb3e4d271c76859d26bde57242d64fe1632ab636f5319f"
+                "sha256:e460a71c12b9e7c57ed9d27e2953d0318fe758d5089256bba41dd0b5177355b1",
+                "sha256:fdf0f13eea9e4aee9d6bffee4f6ff05c81f41e3fbeb9642189516d9dc67978c9"
             ],
-            "version": "==8.9.15"
+            "version": "==8.9.16"
         },
         "phonenumberslite": {
             "hashes": [
-                "sha256:570ec0853a2b501bc5e383c935311932d3a3f39bfb7c544dfcc0d0070032ff42",
-                "sha256:c78b269aff4dd731cd8c99960bc67dcd2ac830e23354c5f6d27b0512b8a129be"
+                "sha256:2db0b001d9103488fc7a2c844c5b2b565557652e1b75607315652063769a2aea",
+                "sha256:fa01b5ef3581dcc66ba8fcb91b3d3e4e2a82b0b232d71e24b8e345915b0b3318"
             ],
             "index": "pypi",
-            "version": "==8.9.15"
+            "version": "==8.9.16"
         },
         "pillow": {
             "hashes": [
@@ -688,6 +756,27 @@
             ],
             "version": "==2.2.1"
         },
+        "protobuf": {
+            "hashes": [
+                "sha256:10394a4d03af7060fa8a6e1cbf38cea44be1467053b0aea5bbfcb4b13c4b88c4",
+                "sha256:1489b376b0f364bcc6f89519718c057eb191d7ad6f1b395ffd93d1aa45587811",
+                "sha256:1931d8efce896981fe410c802fd66df14f9f429c32a72dd9cfeeac9815ec6444",
+                "sha256:196d3a80f93c537f27d2a19a4fafb826fb4c331b0b99110f985119391d170f96",
+                "sha256:46e34fdcc2b1f2620172d3a4885128705a4e658b9b62355ae5e98f9ea19f42c2",
+                "sha256:4b92e235a3afd42e7493b281c8b80c0c65cbef45de30f43d571d1ee40a1f77ef",
+                "sha256:574085a33ca0d2c67433e5f3e9a0965c487410d6cb3406c83bdaf549bfc2992e",
+                "sha256:59cd75ded98094d3cf2d79e84cdb38a46e33e7441b2826f3838dcc7c07f82995",
+                "sha256:5ee0522eed6680bb5bac5b6d738f7b0923b3cafce8c4b1a039a6107f0841d7ed",
+                "sha256:65917cfd5da9dfc993d5684643063318a2e875f798047911a9dd71ca066641c9",
+                "sha256:685bc4ec61a50f7360c9fd18e277b65db90105adbf9c79938bd315435e526b90",
+                "sha256:92e8418976e52201364a3174e40dc31f5fd8c147186d72380cbda54e0464ee19",
+                "sha256:9335f79d1940dfb9bcaf8ec881fb8ab47d7a2c721fb8b02949aab8bbf8b68625",
+                "sha256:a7ee3bb6de78185e5411487bef8bc1c59ebd97e47713cba3c460ef44e99b3db9",
+                "sha256:ceec283da2323e2431c49de58f80e1718986b79be59c266bb0509cbf90ca5b9e",
+                "sha256:fcfc907746ec22716f05ea96b7f41597dfe1a1c088f861efb8a0d4f4196a6f10"
+            ],
+            "version": "==3.6.1"
+        },
         "psycopg2-binary": {
             "hashes": [
                 "sha256:04afb59bbbd2eab3148e6816beddc74348078b8c02a1113ea7f7822f5be4afe3",
@@ -732,6 +821,20 @@
             "index": "pypi",
             "version": "==1.4"
         },
+        "pyasn1": {
+            "hashes": [
+                "sha256:b9d3abc5031e61927c82d4d96c1cec1e55676c1a991623cfed28faea73cdd7ca",
+                "sha256:f58f2a3d12fd754aa123e9fa74fb7345333000a035f3921dbdaa08597aa53137"
+            ],
+            "version": "==0.4.4"
+        },
+        "pyasn1-modules": {
+            "hashes": [
+                "sha256:a0cf3e1842e7c60fde97cb22d275eb6f9524f5c5250489e292529de841417547",
+                "sha256:a38a8811ea784c0136abfdba73963876328f66172db21a05a82f9515909bfb4e"
+            ],
+            "version": "==0.2.2"
+        },
         "pycodestyle": {
             "hashes": [
                 "sha256:cbc619d09254895b0d12c2c691e237b2e91e9b2ecf5e84c26b35400f93dcfb83",
@@ -768,11 +871,11 @@
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:1adb80e7a782c12e52ef9a8182bebeb73f1d7e24e374397af06fb4956c8dc5c0",
-                "sha256:e27001de32f627c22380a688bcc43ce83504a7bc5da472209b4c70f02829f0b8"
+                "sha256:2f13d3ea236aeb237e7258d5729c46eafe1506fd7f8507f34730734ed8b37454",
+                "sha256:f7cde3aecf8a797553d6ec49b65f0fbcffe7ffb971ccac452d181c28fd279936"
             ],
             "markers": "python_version >= '2.7'",
-            "version": "==2.7.3"
+            "version": "==2.7.4"
         },
         "python3-openid": {
             "hashes": [
@@ -784,10 +887,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:a061aa0a9e06881eb8b3b2b43f05b9439d6583c206d0a6c340ff72a7b6669053",
-                "sha256:ffb9ef1de172603304d9d2819af6f5ece76f2e85ec10692a524dd876e72bf277"
+                "sha256:642253af8eae734d1509fc6ac9c1aee5e5b69d76392660889979b9870610a46b",
+                "sha256:91e3ccf2c344ffaa6defba1ce7f38f97026943f675b7703f44789768e4cb0ece"
             ],
-            "version": "==2018.5"
+            "version": "==2018.6"
         },
         "raven": {
             "hashes": [
@@ -802,15 +905,16 @@
                 "sha256:8a1900a9f2a0a44ecf6e8b5eb3e967a9909dfed219ad66df094f27f7d6f330fb",
                 "sha256:a22ca993cea2962dbb588f9f30d0015ac4afcc45bee27d3978c0dbe9e97c6c0f"
             ],
+            "markers": "extra == 'redis'",
             "version": "==2.10.6"
         },
         "requests": {
             "hashes": [
-                "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
-                "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
+                "sha256:99dcfdaaeb17caf6e526f32b6a7b780461512ab3f1d992187801694cba42770c",
+                "sha256:a84b8c9ab6239b578f22d1c21d51b696dcfe004032bb80ea832398d6909d7279"
             ],
             "index": "pypi",
-            "version": "==2.19.1"
+            "version": "==2.20.0"
         },
         "requests-oauthlib": {
             "hashes": [
@@ -818,6 +922,13 @@
                 "sha256:e21232e2465808c0e892e0e4dbb8c2faafec16ac6dc067dd546e9b466f3deac8"
             ],
             "version": "==1.0.0"
+        },
+        "rsa": {
+            "hashes": [
+                "sha256:14ba45700ff1ec9eeb206a2ce76b32814958a98e372006c8fb76ba820211be66",
+                "sha256:1a836406405730121ae9823e19c6e806c62bbad73f890574fff50efa4122c487"
+            ],
+            "version": "==4.0"
         },
         "rx": {
             "hashes": [
@@ -916,10 +1027,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
-                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
+                "sha256:41c3db2fc01e5b907288010dec72f9d0a74e37d6994e6eb56849f59fea2265ae",
+                "sha256:8819bba37a02d143296a4d032373c4dd4aca11f6d4c9973335ca75f9c8475f59"
             ],
-            "version": "==1.23"
+            "markers": "python_version >= '3.4'",
+            "version": "==1.24"
         },
         "uwsgi": {
             "hashes": [
@@ -990,10 +1102,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:376690d6f16d32f9d1fe8932551d80b23e9d393a8578c5633a2ed39a64861638",
-                "sha256:456048c7e371c089d0a77a5212fb37a2c2dce1e24146e3b7e0261736aaeaa22a"
+                "sha256:339dc09518b07e2fa7eda5450740925974815557727d6bd35d319c1524a04a4c",
+                "sha256:6d58c986d22b038c8c0df30d639f23a3e6d172a05c3583e766f4c0b785c0986a"
             ],
-            "version": "==2018.8.24"
+            "version": "==2018.10.15"
         },
         "chardet": {
             "hashes": [
@@ -1014,6 +1126,7 @@
             "hashes": [
                 "sha256:03481e81d558d30d230bc12999e3edffe392d244349a90f4ef9b88425fac74ba",
                 "sha256:0b136648de27201056c1869a6c0d4e23f464750fd9a9ba9750b8336a244429ed",
+                "sha256:0bf8cbbd71adfff0ef1f3a1531e6402d13b7b01ac50a79c97ca15f030dba6306",
                 "sha256:10a46017fef60e16694a30627319f38a2b9b52e90182dddb6e37dcdab0f4bf95",
                 "sha256:198626739a79b09fa0a2f06e083ffd12eb55449b5f8bfdbeed1df4910b2ca640",
                 "sha256:23d341cdd4a0371820eb2b0bd6b88f5003a7438bbedb33688cd33b8eae59affd",
@@ -1042,6 +1155,7 @@
                 "sha256:c1bb572fab8208c400adaf06a8133ac0712179a334c09224fb11393e920abcdd",
                 "sha256:de4418dadaa1c01d497e539210cb6baa015965526ff5afc078c57ca69160108d",
                 "sha256:e05cb4d9aad6233d67e0541caa7e511fa4047ed7750ec2510d466e806e0255d6",
+                "sha256:f05a636b4564104120111800021a92e43397bc12a5c72fed7036be8556e0029e",
                 "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80"
             ],
             "index": "pypi",
@@ -1170,17 +1284,17 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:6e3836e39f4d36ae72840833db137f7b7d35105079aee6ec4a62d9f80d594dd1",
-                "sha256:95eb8364a4708392bae89035f45341871286a333f749c3141c20573d2b3876e1"
+                "sha256:447ba94990e8014ee25ec853339faf7b0fc8050cdc3289d4d71f7f410fb90095",
+                "sha256:bde19360a8ec4dfd8a20dcb811780a30998101f078fc7ded6162f0076f50508f"
             ],
-            "version": "==0.7.1"
+            "version": "==0.8.0"
         },
         "py": {
             "hashes": [
-                "sha256:06a30435d058473046be836d3fc4f27167fd84c45b99704f2fb5509ef61f9af1",
-                "sha256:50402e9d1c9005d759426988a492e0edaadb7f4e68bcddfea586bc7432d009c6"
+                "sha256:bf92637198836372b520efcba9e020c330123be8ce527e535d185ed4b6f45694",
+                "sha256:e76826342cefe3c3d5f7e8ee4316b80d1dd8a300781612ddbc765c17ba25a6c6"
             ],
-            "version": "==1.6.0"
+            "version": "==1.7.0"
         },
         "pycodestyle": {
             "hashes": [
@@ -1191,12 +1305,12 @@
         },
         "pydocstyle": {
             "hashes": [
-                "sha256:08a870edc94508264ed90510db466c6357c7192e0e866561d740624a8fc7d90c",
-                "sha256:4d5bcde961107873bae621f3d580c3e35a426d3687ffc6f8fb356f6628da5a97",
-                "sha256:af9fcccb303899b83bec82dc9a1d56c60fc369973223a5e80c3dfa9bdf984405"
+                "sha256:2258f9b0df68b97bf3a6c29003edc5238ff8879f1efb6f1999988d934e432bd8",
+                "sha256:5741c85e408f9e0ddf873611085e819b809fca90b619f5fd7f34bd4959da3dd4",
+                "sha256:ed79d4ec5e92655eccc21eb0c6cf512e69512b4a97d215ace46d17e4990f2039"
             ],
             "index": "pypi",
-            "version": "==2.1.1"
+            "version": "==3.0.0"
         },
         "pylint": {
             "hashes": [
@@ -1230,11 +1344,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:7e258ee50338f4e46957f9e09a0f10fb1c2d05493fa901d113a8dafd0790de4e",
-                "sha256:9332147e9af2dcf46cd7ceb14d5acadb6564744ddff1fe8c17f0ce60ece7d9a2"
+                "sha256:212be78a6fa5352c392738a49b18f74ae9aeec1040f47c81cadbfd8d1233c310",
+                "sha256:6f6c1efc8d0ccc21f8f6c34d8330baca883cf109b66b3df954b0a117e5528fb4"
             ],
             "index": "pypi",
-            "version": "==3.8.2"
+            "version": "==3.9.2"
         },
         "pytest-cov": {
             "hashes": [
@@ -1301,11 +1415,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
-                "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
+                "sha256:99dcfdaaeb17caf6e526f32b6a7b780461512ab3f1d992187801694cba42770c",
+                "sha256:a84b8c9ab6239b578f22d1c21d51b696dcfe004032bb80ea832398d6909d7279"
             ],
             "index": "pypi",
-            "version": "==2.19.1"
+            "version": "==2.20.0"
         },
         "six": {
             "hashes": [
@@ -1330,11 +1444,11 @@
         },
         "tox": {
             "hashes": [
-                "sha256:0cc11ff7a2c8d3f988bea9f760e14aae02957d4324cb09ef55b802d5cd4562c9",
-                "sha256:dc3ca9c56c544234e1cfc5ac0d40e6b91213a1a3cec78cccd48a41900a93e0e8"
+                "sha256:217fb84aecf9792a98f93f07cfcaf014205a76c64e52bd7c2b4135458e6ad2a1",
+                "sha256:4baeb3d8ebdcd9f43afce38aa67d06f1165a87d221d5bb21e8b39a0d4880c134"
             ],
             "index": "pypi",
-            "version": "==3.5.1"
+            "version": "==3.5.2"
         },
         "typed-ast": {
             "hashes": [
@@ -1367,10 +1481,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
-                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
+                "sha256:41c3db2fc01e5b907288010dec72f9d0a74e37d6994e6eb56849f59fea2265ae",
+                "sha256:8819bba37a02d143296a4d032373c4dd4aca11f6d4c9973335ca75f9c8475f59"
             ],
-            "version": "==1.23"
+            "markers": "python_version >= '3.4'",
+            "version": "==1.24"
         },
         "vcrpy": {
             "hashes": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,17 +2,18 @@
 amqp==2.3.2
 aniso8601==3.0.2
 asn1crypto==0.24.0
-autopep8==1.4
+autopep8==1.4.2
 babel==2.6.0
 billiard==3.5.0.4
 bleach==2.1.4
-boto3==1.9.19
-botocore==1.12.19
-braintree==3.48.0
+boto3==1.9.31
+botocore==1.12.31
+braintree==3.49.0
+cachetools==2.1.0
 cairocffi==0.9.0
 cairosvg==2.2.1
-celery==4.2.1
-certifi==2018.8.24
+celery[redis]==4.2.1
+certifi==2018.10.15
 cffi==1.11.5
 chardet==3.0.4
 cryptography==2.3.1
@@ -31,7 +32,7 @@ django-debug-toolbar==1.10.1
 django-elasticsearch-dsl==0.5.0
 django-filter==2.0.0
 django-fsm==2.6.0
-django-graphql-jwt==0.1.13
+django-graphql-jwt==0.1.14
 django-impersonate==1.3
 django-js-asset==1.1.0
 django-measurement==3.0.0
@@ -53,13 +54,20 @@ django==2.1.2
 docutils==0.14
 elasticsearch-dsl==5.4.0
 elasticsearch==5.5.3
-faker==0.9.1
-freezegun==0.3.10
+faker==0.9.2
+freezegun==0.3.11
+google-api-core==1.5.0
+google-auth==1.5.1
+google-cloud-core==0.28.1
+google-cloud-storage==1.10.0
+google-cloud==0.34.0
 google-i18n-address==2.3.2
 google-measurement-protocol==1.0.0
+google-resumable-media==0.3.1
+googleapis-common-protos==1.5.3
 gprof2dot==2016.10.13
-graphene-django==2.2.0
 graphene-django-optimizer==0.3.5
+graphene-django==2.2.0
 graphene==2.1.3
 graphql-core==2.1
 graphql-relay==0.4.5
@@ -77,25 +85,29 @@ measurement==2.0.1
 mpmath==1.0.0
 oauthlib==2.1.0
 pdfrw==0.4
-phonenumbers==8.9.15
-phonenumberslite==8.9.15
+phonenumbers==8.9.16
+phonenumberslite==8.9.16
 pillow==5.3.0
 prices==1.0.0
 promise==2.2.1
+protobuf==3.6.1
 psycopg2-binary==2.7.5
 purl==1.4
+pyasn1-modules==0.2.2
+pyasn1==0.4.4
 pycodestyle==2.4.0
 pycparser==2.19
 pygments==2.2.0
 pyjwt==1.6.4
 pyphen==0.9.5
-python-dateutil==2.7.3 ; python_version >= '2.7'
+python-dateutil==2.7.4 ; python_version >= '2.7'
 python3-openid==3.1.0 ; python_version >= '3.0'
-pytz==2018.5
+pytz==2018.6
 raven==6.9.0
-redis==2.10.6
+redis==2.10.6 ; extra == 'redis'
 requests-oauthlib==1.0.0
-requests==2.19.1
+requests==2.20.0
+rsa==4.0
 rx==1.6.1
 s3transfer==0.1.13
 singledispatch==3.4.0.3
@@ -109,7 +121,7 @@ sympy==1.3
 text-unidecode==1.2
 tinycss2==0.6.1
 typing==3.6.6
-urllib3==1.23
+urllib3==1.24 ; python_version >= '3.4'
 uwsgi==2.0.17.1 ; platform_system != 'Windows'
 vine==1.1.4
 weasyprint==0.42.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,7 +3,7 @@ apipkg==1.5
 astroid==2.0.4
 atomicwrites==1.2.1
 attrs==18.2.0
-certifi==2018.8.24
+certifi==2018.10.15
 chardet==3.0.4
 codecov==2.0.15
 coverage==4.5.1
@@ -16,10 +16,10 @@ lazy-object-proxy==1.3.1
 mccabe==0.6.1
 more-itertools==4.3.0
 multidict==4.4.2
-pluggy==0.7.1
-py==1.6.0
+pluggy==0.8.0
+py==1.7.0
 pycodestyle==2.4.0
-pydocstyle==2.1.1
+pydocstyle==3.0.0
 pylint-celery==0.3
 pylint-django==2.0.2
 pylint-plugin-utils==0.4
@@ -30,15 +30,15 @@ pytest-forked==0.2
 pytest-mock==1.10.0
 pytest-vcr==0.3.0
 pytest-xdist==1.23.2
-pytest==3.8.2
+pytest==3.9.2
 pyyaml==3.13
-requests==2.19.1
+requests==2.20.0
 six==1.11.0
 snowballstemmer==1.2.1
 toml==0.10.0
-tox==3.5.1
+tox==3.5.2
 typed-ast==1.1.0 ; python_version < '3.7' and implementation_name == 'cpython'
-urllib3==1.23
+urllib3==1.24 ; python_version >= '3.4'
 vcrpy==2.0.1
 virtualenv==16.0.0
 wrapt==1.10.11

--- a/saleor/core/storages.py
+++ b/saleor/core/storages.py
@@ -1,9 +1,16 @@
 from django.conf import settings
 from storages.backends.s3boto3 import S3Boto3Storage
+from storages.backends.gcloud import GoogleCloudStorage
 
 
 class S3MediaStorage(S3Boto3Storage):
     def __init__(self, *args, **kwargs):
         self.bucket_name = settings.AWS_MEDIA_BUCKET_NAME
         self.custom_domain = settings.AWS_MEDIA_CUSTOM_DOMAIN
+        super().__init__(*args, **kwargs)
+
+
+class GCSMediaStorage(GoogleCloudStorage):
+    def __init__(self, *args, **kwargs):
+        self.bucket_name = settings.GS_MEDIA_BUCKET_NAME
         super().__init__(*args, **kwargs)

--- a/saleor/core/storages.py
+++ b/saleor/core/storages.py
@@ -1,6 +1,6 @@
 from django.conf import settings
-from storages.backends.s3boto3 import S3Boto3Storage
 from storages.backends.gcloud import GoogleCloudStorage
+from storages.backends.s3boto3 import S3Boto3Storage
 
 
 class S3MediaStorage(S3Boto3Storage):

--- a/saleor/core/storages.py
+++ b/saleor/core/storages.py
@@ -14,3 +14,9 @@ class GCSMediaStorage(GoogleCloudStorage):
     def __init__(self, *args, **kwargs):
         self.bucket_name = settings.GS_MEDIA_BUCKET_NAME
         super().__init__(*args, **kwargs)
+
+
+class GCSStaticStorage(GoogleCloudStorage):
+    def __init__(self, *args, **kwargs):
+        self.bucket_name = settings.GS_STORAGE_BUCKET_NAME
+        super().__init__(*args, **kwargs)

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -400,7 +400,7 @@ if 'GOOGLE_APPLICATION_CREDENTIALS' not in os.environ:
     GS_CREDENTIALS = os.environ.get('GS_CREDENTIALS')
 
 GS_PROJECT_ID = os.environ.get('GS_PROJECT_ID')
-GS_AUTO_CREATE_BUCKET = os.environ.get('GS_AUTO_CREATE_BUCKET', False)
+GS_AUTO_CREATE_BUCKET = get_bool_from_env('GS_AUTO_CREATE_BUCKET', False)
 
 if AWS_STORAGE_BUCKET_NAME:
     STATICFILES_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -389,11 +389,26 @@ AWS_S3_CUSTOM_DOMAIN = os.environ.get('AWS_STATIC_CUSTOM_DOMAIN')
 AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY')
 AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME')
 
+# Google cloud storage
+GS_BUCKET_NAME = os.environ.get('GS_BUCKET_NAME')
+GS_MEDIA_BUCKET_NAME = os.environ.get('GS_MEDIA_BUCKET_NAME')
+GS_PROJECT_ID = os.environ.get('GS_PROJECT_ID')
+GS_CREDENTIALS = os.environ.get('GS_CREDENTIALS')
+GS_AUTO_CREATE_BUCKET = os.environ.get('GS_AUTO_CREATE_BUCKET', False)
+
+# Alternatively keep the ENV varibable GOOGLE_APPLICATION_CREDENTIALS instead of PROJ_ID and others
+
 if AWS_STORAGE_BUCKET_NAME:
     STATICFILES_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+elif GS_BUCKET_NAME:
+    STATICFILES_STORAGE = 'storages.backends.gcloud.GoogleCloudStorage'
 
 if AWS_MEDIA_BUCKET_NAME:
-    DEFAULT_FILE_STORAGE = 'saleor.core.storages.S3MediaStorage'
+    DEFAULT_FILE_STORAGE = 'saleor.core.storages.MediaStorage'
+    THUMBNAIL_DEFAULT_STORAGE = DEFAULT_FILE_STORAGE
+
+elif GS_MEDIA_BUCKET_NAME:
+    DEFAULT_FILE_STORAGE = 'saleor.core.storages.GCSMediaStorage'
     THUMBNAIL_DEFAULT_STORAGE = DEFAULT_FILE_STORAGE
 
 MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -396,7 +396,7 @@ GS_MEDIA_BUCKET_NAME = os.environ.get('GS_MEDIA_BUCKET_NAME')
 # If GOOGLE_APPLICATION_CREDENTIALS is set with path to JSON credentials,
 # there is no need to load OAuth token
 # See https://django-storages.readthedocs.io/en/latest/backends/gcloud.html
-if not os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
+if 'GOOGLE_APPLICATION_CREDENTIALS' not in os.environ:
     GS_CREDENTIALS = os.environ.get('GS_CREDENTIALS')
 
 GS_PROJECT_ID = os.environ.get('GS_PROJECT_ID')

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -390,23 +390,26 @@ AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY')
 AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME')
 
 # Google cloud storage
-GS_BUCKET_NAME = os.environ.get('GS_BUCKET_NAME')
+GS_STORAGE_BUCKET_NAME = os.environ.get('GS_STORAGE_BUCKET_NAME')
 GS_MEDIA_BUCKET_NAME = os.environ.get('GS_MEDIA_BUCKET_NAME')
-GS_PROJECT_ID = os.environ.get('GS_PROJECT_ID')
-GS_CREDENTIALS = os.environ.get('GS_CREDENTIALS')
-GS_AUTO_CREATE_BUCKET = os.environ.get('GS_AUTO_CREATE_BUCKET', False)
 
-# Alternatively keep the ENV varibable GOOGLE_APPLICATION_CREDENTIALS instead of PROJ_ID and others
+# If GOOGLE_APPLICATION_CREDENTIALS is set with path to JSON credentials,
+# there is no need to load OAuth token
+# See https://django-storages.readthedocs.io/en/latest/backends/gcloud.html
+if not os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
+    GS_CREDENTIALS = os.environ.get('GS_CREDENTIALS')
+
+GS_PROJECT_ID = os.environ.get('GS_PROJECT_ID')
+GS_AUTO_CREATE_BUCKET = os.environ.get('GS_AUTO_CREATE_BUCKET', False)
 
 if AWS_STORAGE_BUCKET_NAME:
     STATICFILES_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
-elif GS_BUCKET_NAME:
-    STATICFILES_STORAGE = 'storages.backends.gcloud.GoogleCloudStorage'
+elif GS_STORAGE_BUCKET_NAME:
+    STATICFILES_STORAGE = 'saleor.core.storages.GCSStaticStorage'
 
 if AWS_MEDIA_BUCKET_NAME:
     DEFAULT_FILE_STORAGE = 'saleor.core.storages.MediaStorage'
     THUMBNAIL_DEFAULT_STORAGE = DEFAULT_FILE_STORAGE
-
 elif GS_MEDIA_BUCKET_NAME:
     DEFAULT_FILE_STORAGE = 'saleor.core.storages.GCSMediaStorage'
     THUMBNAIL_DEFAULT_STORAGE = DEFAULT_FILE_STORAGE


### PR DESCRIPTION
Manually merge [this change](https://github.com/mirumee/saleor/pull/2626/files) to obtain the support for [Google Cloud Storage](https://cloud.google.com/storage/) through [django-storages](https://django-storages.readthedocs.io/en/latest/backends/gcloud.html).

<!-- Please mention all relevant issue numbers. -->

### Reference 
[PR#2626 ](https://github.com/mirumee/saleor/pull/2626)


### Conflicting files
- Pipfile
- Pipfile.lock
- requirements.txt
- requirements_dev.txt

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
